### PR TITLE
Get UID from /proc/self/status to fix Bottles (Flatpak)

### DIFF
--- a/DBus/WineConnectionOptions.cs
+++ b/DBus/WineConnectionOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Tmds.DBus.Protocol;
@@ -11,23 +12,25 @@ public class WineConnectionOptions(string address) : DBusConnectionOptions(addre
 
     protected override ValueTask<SetupResult> SetupAsync(CancellationToken cancellationToken)
     {
-        var dbusSessionAddress = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
-        if (dbusSessionAddress == null)
+        foreach (var line in File.ReadLines("/proc/self/status"))
         {
-            throw new Exception("DBUS_SESSION_BUS_ADDRESS environment variable not set");
+            if (!line.StartsWith("Uid:", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            var parts = line.Split(['\t', ' '], StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2 && uint.TryParse(parts[1], out var userId))
+            {
+                return new ValueTask<SetupResult>(new SetupResult(address)
+                {
+                    // This does not work in wine/windows, will try to DLLImport libc
+                    SupportsFdPassing = false,
+                    UserId = userId.ToString(),
+                    MachineId = "N"
+                });
+            }
+            break;
         }
-
-        if (!int.TryParse(dbusSessionAddress.Replace("unix:path=/run/user/", string.Empty).Replace("/bus", string.Empty), out var userId))
-        {
-            throw new Exception("Failed to get UserId from DBUS_SESSION_BUS_ADDRESS");
-        }
-
-        return new ValueTask<SetupResult>(new SetupResult(address)
-        {
-            // This does not work in wine/windows, will try to DLLImport libc
-            SupportsFdPassing = false,
-            UserId = userId.ToString(),
-            MachineId = "N"
-        });
+        throw new Exception("Failed to get Linux UserId from /proc/self/status");
     }
 }

--- a/MPRISBee.cs
+++ b/MPRISBee.cs
@@ -74,7 +74,7 @@ namespace MusicBeePlugin
             about.Type = PluginType.General;
             about.VersionMajor = 1; // your plugin version
             about.VersionMinor = 0;
-            about.Revision = 1;
+            about.Revision = 2;
             about.MinInterfaceVersion = MinInterfaceVersion;
             about.MinApiRevision = MinApiRevision;
             about.ReceiveNotifications = (ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents);

--- a/MPRISBee.csproj
+++ b/MPRISBee.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <AssemblyName>mb_MPRISBee</AssemblyName>
     <AssemblyTitle>MPRISBee</AssemblyTitle>
     <RootNamespace>MusicBeePlugin</RootNamespace>


### PR DESCRIPTION
WineConnectionOptions got the UID by parsing the env variable DBUS_SESSION_BUS_ADDRESS.

This fails when the session bus uses a different address, such as when using Bottles (Flatpak), as the variable will be unix:path=/run/flatpak/bus.

This was fixed by getting the UID directly from /proc/self/status.